### PR TITLE
Fix pillow dependency specifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
 plugin_requires = [
-    "pillow >=6.2.0<7.0.0", # since 7.0.0 no Python 2.7 Support, see https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst
+    "pillow >=6.2.0, <7.0.0", # since 7.0.0 no Python 2.7 Support, see https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst
     "qrcode",
     "peewee"
     # "psycopg2-binary",  # postgres - driver


### PR DESCRIPTION
Copied from https://github.com/mdziekon/OctoPrint-SpoolManager/pull/33/files